### PR TITLE
Improvement animation

### DIFF
--- a/Assets/Scripts/AnimationEngine.js
+++ b/Assets/Scripts/AnimationEngine.js
@@ -916,7 +916,7 @@ class ParticleHF {
 // Class that manages the particle system
 class ParticleSystem {
   // Variables
-  fullScreenNumParticles = 30000;
+  fullScreenNumParticles = 20000;
   speedFactor = 0.7;
   fullScreenPixels = 1920 * 1080;
   minParticles = 4000;
@@ -997,7 +997,7 @@ class ParticleSystem {
       // Density
       let density = this.numParticles / (numPixels * Math.min(100,percentageAreaOnScreen) / 100);
       //console.log("Particle density: " + density);
-      if (density > 0.1){
+      if (density > 0.07){
         this.numParticles = Math.floor((numPixels * Math.min(100,percentageAreaOnScreen) / 100) * 0.1);
         // Limit
         this.numParticles = Math.min(this.numParticles, this.fullScreenNumParticles);
@@ -1037,7 +1037,13 @@ class ParticleSystem {
     // Trail effect
     // https://codepen.io/Tyriar/pen/BfizE
     if (this.particles[0].constructor.name != 'Arrow'){
-      this.ctx.fillStyle = 'rgba(255, 255, 255, .9)';
+      //this.ctx.fillStyle = 'rgba(255, 255, 255, .9)';
+      // Adaptive path length
+      let zoom = this.map.getView().getZoom();
+      let alpha = 0.98 - 0.1*(zoom - 8.5) / 2;
+      alpha = Math.min(0.96, alpha); // Limit to 0.98 for far away zoom
+      this.ctx.fillStyle = 'rgba(255, 255, 255, '+ alpha +')';
+
       this.ctx.globalCompositeOperation = "destination-in";
       this.ctx.fillRect(0,0, this.canvas.width, this.canvas.height);
       this.ctx.globalCompositeOperation = "source-over";
@@ -1352,13 +1358,12 @@ class ParticleCombinedRadar extends Particle {
   constructor(particleSystem){
     super(particleSystem);
 
-    particleSystem.speedFactor = 0.1;
-    //this.stepInLongLat = 0.008;
+    particleSystem.speedFactor = 0.2;
     this.stepInLongLat = 0.02;
     this.color = [255,255,255];
 
     // Intial properties
-    this.maxNumVerticesPath = 10//this.numVerticesPath;
+    this.maxNumVerticesPath = this.numVerticesPath;
     this.mustDiscard = false;
   }
 
@@ -1488,7 +1493,9 @@ class ParticleCombinedRadar extends Particle {
     this.particleSystem.drawCalls++;
 
     // Update life
-    this.life += 0.01 * this.particleSystem.speedFactor / (this.numVerticesPath / 200);// + this.particleSystem.speedFactor * 0.1 * this.verticesValue[Math.round(this.life * this.numVerticesPath)];
+    // The increase in life (speed) depends on the number of vertices in the path
+    this.life += 0.01 * this.particleSystem.speedFactor / (this.numVerticesPath / 200);
+    
 
     if (this.life > 1){
       this.life = 0;
@@ -1531,13 +1538,7 @@ class ParticleCombinedRadar extends Particle {
     this.currentPos[1] = interpCoeff * this.vertices[prevVertPath*2 + 1]  +
                 (1-interpCoeff) * this.vertices[nextVertPath*2 + 1];
 
-    // let dist = Math.sqrt((this.vertices[prevVertPath*2] - this.vertices[nextVertPath*2]) * (this.vertices[prevVertPath*2] - this.vertices[nextVertPath*2]) +
-    // (this.vertices[prevVertPath*2+1] - this.vertices[nextVertPath*2+1]) * (this.vertices[prevVertPath*2+1] - this.vertices[nextVertPath*2+1]));
-    // if (dist > 100 ){
-    //   this.prevPos[0] = undefined;
-    //   this.prevPos[1] = undefined;
-    //   return;
-    // }
+
 
     // When prevPos is not valid (map moved, source changed, etc)
     if (this.prevPos[0] == undefined){

--- a/Assets/Scripts/AnimationEngine.js
+++ b/Assets/Scripts/AnimationEngine.js
@@ -1398,27 +1398,7 @@ class ParticleCombinedRadar extends Particle {
       let nextLong = coord[0] + ((this.valueVec2[0] * step) / earthRadius) * (180 / Math.PI) / Math.cos(coord[0] * Math.PI / 180);
       let nextLat = coord[1] + ((this.valueVec2[1] * step) / earthRadius) * (180 / Math.PI);
 
-      // DEBUG
-      // Distance between prev an next pos
-      let dist = Math.sqrt((nextLong - coord[0]) * (nextLong - coord[0]) + (nextLat - coord[1]) * (nextLat - coord[1]));
-      let module = Math.sqrt(this.valueVec2[0]*this.valueVec2[0] + this.valueVec2[1]*this.valueVec2[1]);
-      console.log(module + ", " + dist + ", Vec: " + this.valueVec2[0].toFixed(2) + ", " + this.valueVec2[1].toFixed(2));
-     
-      if (dist > step*8){
-        // TODO: for some reason, generatePoint makes the valueVec2 have extreme values (1000 cm/s for example)
-        // Possible causes for the bug --> files have errors, DataManager messes up.
-        //console.log(dist);
-        let tmp = i; // Store new number of vertices before undefined
-        i = this.numVerticesPath; // Exit loop
-        this.numVerticesPathWithData = tmp - 1; // Define new number of vertices per path for this particle
-        debugger;
-        this.valueVec2[0] = undefined;
-        this.valueVec2[1] = undefined;
-        continue;
-      } else {
-
-      }
-
+      
       // Convert to pixel coordinates
       coord[0] = nextLong;
       coord[1] = nextLat;

--- a/Assets/Scripts/DataManager.js
+++ b/Assets/Scripts/DataManager.js
@@ -1040,9 +1040,11 @@ class CombinedRadars extends HFRadar {
           UValue = dataPoint['U-comp (cm/s)'];
           VValue = dataPoint['V-comp (cm/s)'];
 
-          // TODO HERE
-          // CHECK IF DATA POINT HAS EXTREME VALUES
-          debugger;
+          // When using tuv files there is no quality control and some values are out of range
+          if (Math.abs(UValue) > 250 || Math.abs(VValue) > 250){
+            UValue = undefined;
+            VValue = undefined;
+          }
         }
         // Linear interpolation
         else {
@@ -1056,9 +1058,11 @@ class CombinedRadars extends HFRadar {
           UValue = dataPoint1['U-comp (cm/s)'] * (1 - d1/totD) + dataPoint2['U-comp (cm/s)'] * (d1 / totD);
           VValue = dataPoint1['V-comp (cm/s)'] * (1 - d1/totD) + dataPoint2['V-comp (cm/s)'] * (d1 / totD);
 
-          // TODO HERE
-          // CHECK IF DATA POINT HAS EXTREME VALUES
-          debugger;
+          // When using tuv files there is no quality control and some values are out of range
+          if (Math.abs(UValue) > 250 || Math.abs(VValue) > 250){
+            UValue = undefined;
+            VValue = undefined;
+          }
         }
 
       }
@@ -1068,9 +1072,6 @@ class CombinedRadars extends HFRadar {
       dataGrid[ii * 2] = UValue;
       dataGrid[ii * 2 + 1] = VValue;
 
-      // TODO: CHECK IF A DATA POINT HAS EXTREME VALUES
-      if (UValue > 1000)
-        debugger;
 
       // Point towards the data point location
       // if (closestDataPoint != undefined){

--- a/Assets/Scripts/DataManager.js
+++ b/Assets/Scripts/DataManager.js
@@ -1029,6 +1029,8 @@ class CombinedRadars extends HFRadar {
       // TODO: something wrong with the distance calculation?
       let UValue = undefined;
       let VValue = undefined;
+
+      let threePointInterpPossible = dataPointDistances.length >= 3;
       // let closestDataPoint = undefined;
       // let secondClosest = undefined;
       if (dataPointDistances.length != 0){
@@ -1039,32 +1041,78 @@ class CombinedRadars extends HFRadar {
         if (dataPointDistances.length == 1){
           UValue = dataPoint['U-comp (cm/s)'];
           VValue = dataPoint['V-comp (cm/s)'];
-
-          // When using tuv files there is no quality control and some values are out of range
-          if (Math.abs(UValue) > 250 || Math.abs(VValue) > 250){
-            UValue = undefined;
-            VValue = undefined;
-          }
         }
-        // Linear interpolation
+        // Other interpolation methods (triangular with areas and linear interpolation)
         else {
-          let d1 = dataPointDistances[0][0];
-          let d2 = dataPointDistances[1][0];
-          let totD = d1 + d2;
-          let dataPoint1 = data[dataPointDistances[0][1]];
-          let dataPoint2 = data[dataPointDistances[1][1]];
-          // secondClosest = dataPoint2;
+          // Check if it is possible to do interpolation between three points
+          // Three points that form a triangle
+          if (threePointInterpPossible){
+            // Calculate interpolation of a triangle using areas
+            let getTriangleArea = (x0, y0, x1, y1, x2, y2) => {
+              return Math.abs(0.5 *  ( x0 * (y1 - y2) + x1 * (y2 - y0) + x2 * (y0 - y1) ));
+            }
 
-          UValue = dataPoint1['U-comp (cm/s)'] * (1 - d1/totD) + dataPoint2['U-comp (cm/s)'] * (d1 / totD);
-          VValue = dataPoint1['V-comp (cm/s)'] * (1 - d1/totD) + dataPoint2['V-comp (cm/s)'] * (d1 / totD);
+            let A = data[dataPointDistances[0][1]];
+            let B = data[dataPointDistances[1][1]];
+            let C = data[dataPointDistances[2][1]];
 
-          // When using tuv files there is no quality control and some values are out of range
-          if (Math.abs(UValue) > 250 || Math.abs(VValue) > 250){
-            UValue = undefined;
-            VValue = undefined;
+            // Area P - B - C
+            let areaA = getTriangleArea(long, lat, B['Longitude (deg)'], B['Latitude (deg)'], C['Longitude (deg)'], C['Latitude (deg)']);
+            // Area P - A - C
+            let areaB = getTriangleArea(long, lat, A['Longitude (deg)'], A['Latitude (deg)'], C['Longitude (deg)'], C['Latitude (deg)']);
+            // Area P - A - B
+            let areaC = getTriangleArea(long, lat, A['Longitude (deg)'], A['Latitude (deg)'], B['Longitude (deg)'], B['Latitude (deg)']);
+
+            //let areas = calcVoronoiArea(long, lat, A['Longitude (deg)'], A['Latitude (deg)'], B['Longitude (deg)'], B['Latitude (deg)'], C['Longitude (deg)'], C['Latitude (deg)']);
+            let totalArea = getTriangleArea(A['Longitude (deg)'], A['Latitude (deg)'], B['Longitude (deg)'], B['Latitude (deg)'], C['Longitude (deg)'], C['Latitude (deg)']);
+            
+            // Total area should match the sum of the three areas. Otherwise the point is outside the triangle
+            let isInsideTriangle = Math.abs(areaA + areaB + areaC - totalArea) < 10e-16;
+
+            //console.log(Math.abs(areaA + areaB + areaC - totalArea));
+
+            if (isInsideTriangle) {
+              let w1 = areaA / totalArea;
+              let w2 = areaB / totalArea;
+              let w3 = areaC / totalArea;
+
+              // Comparison with distances
+              // let dw1 = 1 / dataPointDistances[0][0];
+              // let dw2 = 1 / dataPointDistances[1][0];
+              // let dw3 = 1 / dataPointDistances[2][0];
+              // let ddw1 = dw1 / (dw1 + dw2 + dw3);
+              // let ddw2 = dw2 / (dw1 + dw2 + dw3);
+              // let ddw3 = dw3 / (dw1 + dw2 + dw3);
+
+              UValue = A['U-comp (cm/s)'] * w1 + B['U-comp (cm/s)'] * w2 + C['U-comp (cm/s)'] * w3;
+              VValue = A['V-comp (cm/s)'] * w1 + B['V-comp (cm/s)'] * w2 + C['V-comp (cm/s)'] * w3;
+
+            }
+            else
+            threePointInterpPossible = false;
           }
-        }
 
+          // Linear interpolation
+          if (!threePointInterpPossible) {
+            let d1 = dataPointDistances[0][0];
+            let d2 = dataPointDistances[1][0];
+            let totD = d1 + d2;
+            let dataPoint1 = data[dataPointDistances[0][1]];
+            let dataPoint2 = data[dataPointDistances[1][1]];
+            // secondClosest = dataPoint2;
+
+            UValue = dataPoint1['U-comp (cm/s)'] * (1 - d1/totD) + dataPoint2['U-comp (cm/s)'] * (d1 / totD);
+            VValue = dataPoint1['V-comp (cm/s)'] * (1 - d1/totD) + dataPoint2['V-comp (cm/s)'] * (d1 / totD);
+          }
+        } // End of linear or triangular interpolation
+
+      } // End of -is there a close point-
+
+
+      // When using tuv files there is no quality control and some values are out of range
+      if (Math.abs(UValue) > 250 || Math.abs(VValue) > 250){
+        UValue = undefined;
+        VValue = undefined;
       }
 
       // Assign

--- a/Assets/Scripts/DataManager.js
+++ b/Assets/Scripts/DataManager.js
@@ -1039,6 +1039,10 @@ class CombinedRadars extends HFRadar {
         if (dataPointDistances.length == 1){
           UValue = dataPoint['U-comp (cm/s)'];
           VValue = dataPoint['V-comp (cm/s)'];
+
+          // TODO HERE
+          // CHECK IF DATA POINT HAS EXTREME VALUES
+          debugger;
         }
         // Linear interpolation
         else {
@@ -1051,6 +1055,10 @@ class CombinedRadars extends HFRadar {
 
           UValue = dataPoint1['U-comp (cm/s)'] * (1 - d1/totD) + dataPoint2['U-comp (cm/s)'] * (d1 / totD);
           VValue = dataPoint1['V-comp (cm/s)'] * (1 - d1/totD) + dataPoint2['V-comp (cm/s)'] * (d1 / totD);
+
+          // TODO HERE
+          // CHECK IF DATA POINT HAS EXTREME VALUES
+          debugger;
         }
 
       }
@@ -1059,6 +1067,10 @@ class CombinedRadars extends HFRadar {
       // undefined turns into NaN for FloatArray32
       dataGrid[ii * 2] = UValue;
       dataGrid[ii * 2 + 1] = VValue;
+
+      // TODO: CHECK IF A DATA POINT HAS EXTREME VALUES
+      if (UValue > 1000)
+        debugger;
 
       // Point towards the data point location
       // if (closestDataPoint != undefined){


### PR DESCRIPTION
Improved rendering performance and changed how the particles are updated for the combined radar.

The zoom affects how the particles are rendered (further away, the path is longer - closer the path is shorter in terms of lat long).

There was an error with the update loop of the particles. the life of a particle depended on the velocity value. this was wrong, as the path of the particle changed distance according to the speed. Therefore the velocity was used twice in a particle (in the path and in the draw update - life).

Also added triangular interpolation when there are three data points close to a grid cell. 

Tuv files do not have QC (some points had 2000 cm/s. A line of code was added to prevent this outliers. In the future geojsons should be used.

Some of the variables of the particle system are linked. For example, the zoom changes how long the path of a particle is (how long it stays on screen). To avoid linking many variables, such as particle speed, number of particles, step in lat long... I decided that these variables should be adjusted manually. In case the user had the option to reduce the number of particles or other parameters, this interlink between variables should be looked at.